### PR TITLE
Add Swiftformat to enforce consistent Swift style

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,27 @@
+# file options
+
+--symlinks ignore
+--swiftversion 5.1
+
+# rules
+--enable isEmpty
+--disable andOperator
+
+# format options
+
+--closingparen same-line
+--commas inline
+--comments indent
+--decimalgrouping 3,5
+--exponentcase lowercase
+--exponentgrouping disabled
+--fractiongrouping disabled
+--ifdef no-indent
+--importgrouping testable-top
+--operatorfunc no-space
+--nospaceoperators ..<, ...
+--selfrequired validate
+--stripunusedargs closure-only
+--wraparguments after-first
+--wrapcollections after-first
+--wrapparameters after-first

--- a/KafeityViewKit/DynamicController/CellData.swift
+++ b/KafeityViewKit/DynamicController/CellData.swift
@@ -8,54 +8,51 @@
 
 import UIKit
 
-
 public class CellData {
-    
     public typealias TableIndexHandlerType = FWTwo<UITableView, IndexPath>
     public typealias TableCellHandlerType = FWTwoOut<UITableView, IndexPath, UITableViewCell>
-    
+
     public let cell: TableCellHandlerType
     public private(set) var height: FWOneOut<UITableView, CGFloat>?
-    
+
     public let select: TableIndexHandlerType?
     public let segue: String?
     public let showAccessoryIndicator: Bool
-    
+
     public var autoHeight = false
-    
+
     public convenience init(cell: TableCellHandlerType) {
         self.init(cell: cell, segue: nil)
     }
-    
+
     public convenience init(nCell: TableCellHandlerType) {
         self.init(cell: nCell, segue: nil, showAccessoryIndicator: false)
     }
-    
+
     public convenience init(cell: TableCellHandlerType, staticHeight: CGFloat, select: TableIndexHandlerType? = nil, showAccessoryIndicator: Bool = true) {
         self.init(cell: cell, height: nil, select: select, showAccessoryIndicator: showAccessoryIndicator)
-        height = FWOneOut(self, { (owner) in return { tableView in return staticHeight }})
+        height = FWOneOut(self) { _ in { _ in staticHeight } }
     }
-    
+
     public convenience init(nCell: TableCellHandlerType, staticHeight: CGFloat, select: TableIndexHandlerType? = nil) {
         self.init(cell: nCell, height: nil, select: select, showAccessoryIndicator: false)
-        height = FWOneOut(self, { (owner) in return { tableView in return staticHeight }})
+        height = FWOneOut(self) { _ in { _ in staticHeight } }
     }
-    
+
     public convenience init(cell: TableCellHandlerType, select: TableIndexHandlerType? = nil, segue: String? = nil, showAccessoryIndicator: Bool = true) {
         self.init(cell: cell, height: nil, select: select, segue: segue, showAccessoryIndicator: showAccessoryIndicator)
     }
-    
+
     public convenience init(nCell: TableCellHandlerType, height: FWOneOut<UITableView, CGFloat>? = nil, select: TableIndexHandlerType? = nil) {
         self.init(cell: nCell, height: nil, select: select, segue: nil, showAccessoryIndicator: false)
     }
-    
+
     public init(cell: TableCellHandlerType, height: FWOneOut<UITableView, CGFloat>?, select: TableIndexHandlerType? = nil, segue: String? = nil, showAccessoryIndicator: Bool = true) {
         self.segue = segue
         self.showAccessoryIndicator = showAccessoryIndicator
-        
+
         self.cell = cell
         self.height = height
         self.select = select
     }
-    
 }

--- a/KafeityViewKit/DynamicController/DynamicTableView.swift
+++ b/KafeityViewKit/DynamicController/DynamicTableView.swift
@@ -6,183 +6,174 @@
 //  Copyright © 2020 SKOUMAL, s.r.o. All rights reserved.
 //
 
-import UIKit
-import RxSwift
 import RxCocoa
-
+import RxSwift
+import UIKit
 
 open class DynamicTableView: UITableView, UITableViewDataSource, UITableViewDelegate {
-    
     open var defaultCellHeight: CGFloat {
         set {
             dynamicLogic.defaultCellHeight = newValue
         }
         get {
-            return dynamicLogic.defaultCellHeight
+            dynamicLogic.defaultCellHeight
         }
     }
-    
+
     open var defaultSectionHeight: CGFloat {
         set {
             dynamicLogic.defaultSectionHeight = newValue
         }
         get {
-            return dynamicLogic.defaultSectionHeight
+            dynamicLogic.defaultSectionHeight
         }
     }
-    
+
     open var registerNibsHandler: (() -> Void)? {
         set {
             dynamicLogic.registerNibsHandler = newValue
         }
         get {
-            return dynamicLogic.registerNibsHandler
+            dynamicLogic.registerNibsHandler
         }
     }
-    
+
     open var reloadDataHandler: (() -> Void)? {
         set {
             dynamicLogic.reloadDataHandler = newValue
         }
         get {
-            return dynamicLogic.reloadDataHandler
+            dynamicLogic.reloadDataHandler
         }
     }
-    
+
     open var controller: UIViewController? {
         set {
             dynamicLogic.controller = newValue
         }
         get {
-            return dynamicLogic.controller
+            dynamicLogic.controller
         }
     }
-    
+
     open var sections: BehaviorRelay<[Section<CellData>]> {
-        return dynamicLogic.sections
+        dynamicLogic.sections
     }
-    
+
     public let disposeBag = DisposeBag()
-    
+
     open override var tableHeaderView: UIView? {
         get {
-            return super.tableHeaderView
+            super.tableHeaderView
         }
         set {
             super.tableHeaderView = newValue
         }
     }
-    
+
     public let dynamicLogic = DynamicTableViewLogic()
-    
+
     public init(style: UITableView.Style) {
         super.init(frame: CGRect.zero, style: style)
         configuration()
     }
-    
+
     public override init(frame: CGRect, style: UITableView.Style) {
         super.init(frame: frame, style: style)
         configuration()
     }
-    
+
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         configuration()
     }
-    
+
     open override func awakeFromNib() {
         super.awakeFromNib()
         configuration()
     }
-    
+
     open override func didMoveToSuperview() {
         super.didMoveToSuperview()
-        //let sections = setupData()
-        //Observable.just(sections).bind(to: self.sections).dispose()
+        // let sections = setupData()
+        // Observable.just(sections).bind(to: self.sections).dispose()
     }
-    
+
     private func configuration() {
         dataSource = self
         delegate = self
-        
+
         dynamicLogic.tableView = self
         dynamicLogic.registerNibsHandler = registerNibs
         dynamicLogic.reloadDataHandler = reloadData
-        
+
         setup()
         bind()
     }
-    
+
     // MARK: - Logic
-    
-    open func setup() {
-        
-    }
-    
-    open func registerNibs() {
-        
-    }
-    
-    open func bind() {
-        
-    }
-    
+
+    open func setup() {}
+
+    open func registerNibs() {}
+
+    open func bind() {}
+
     open override func reloadData() {
         super.reloadData()
     }
-    
+
     open func setupData() -> [Section<CellData>] {
-        return []
+        []
     }
-    
+
     // MARK: - Table view
-    
+
     open func numberOfSections(in tableView: UITableView) -> Int {
-        return dynamicLogic.numberOfSections(in: tableView)
+        dynamicLogic.numberOfSections(in: tableView)
     }
-    
+
     open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return dynamicLogic.tableView(tableView, numberOfRowsInSection: section)
+        dynamicLogic.tableView(tableView, numberOfRowsInSection: section)
     }
-    
+
     open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        return dynamicLogic.tableView(tableView, cellForRowAt: indexPath)
+        dynamicLogic.tableView(tableView, cellForRowAt: indexPath)
     }
-    
+
     open func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return dynamicLogic.tableView(tableView, titleForHeaderInSection: section)
+        dynamicLogic.tableView(tableView, titleForHeaderInSection: section)
     }
-    
+
     open func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        return dynamicLogic.tableView(tableView, titleForFooterInSection: section)
+        dynamicLogic.tableView(tableView, titleForFooterInSection: section)
     }
-    
+
     open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        return dynamicLogic.tableView(tableView, viewForHeaderInSection: section)
+        dynamicLogic.tableView(tableView, viewForHeaderInSection: section)
     }
-    
+
     open func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return dynamicLogic.tableView(tableView, heightForHeaderInSection: section)
+        dynamicLogic.tableView(tableView, heightForHeaderInSection: section)
     }
-    
+
     open func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        return dynamicLogic.tableView(tableView, viewForFooterInSection: section)
+        dynamicLogic.tableView(tableView, viewForFooterInSection: section)
     }
-    
+
     open func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return dynamicLogic.tableView(tableView, heightForFooterInSection: section)
+        dynamicLogic.tableView(tableView, heightForFooterInSection: section)
     }
-    
+
     open func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return dynamicLogic.tableView(tableView, heightForRowAt: indexPath)
+        dynamicLogic.tableView(tableView, heightForRowAt: indexPath)
     }
-    
+
     open func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
-        return dynamicLogic.tableView(tableView, shouldHighlightRowAt: indexPath)
+        dynamicLogic.tableView(tableView, shouldHighlightRowAt: indexPath)
     }
-    
+
     open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         dynamicLogic.tableView(tableView, didSelectRowAt: indexPath)
     }
-
 }

--- a/KafeityViewKit/DynamicController/DynamicTableViewController.swift
+++ b/KafeityViewKit/DynamicController/DynamicTableViewController.swift
@@ -6,127 +6,119 @@
 //  Copyright © 2020 SKOUMAL, s.r.o. All rights reserved.
 //
 
-import UIKit
-import RxSwift
 import RxCocoa
+import RxSwift
+import UIKit
 
 open class DynamicTableViewController: UITableViewController {
-    
     open var defaultCellHeight: CGFloat {
         set {
             dynamicLogic.defaultCellHeight = newValue
         }
         get {
-            return dynamicLogic.defaultCellHeight
+            dynamicLogic.defaultCellHeight
         }
     }
-    
+
     open var defaultSectionHeight: CGFloat {
         set {
             dynamicLogic.defaultSectionHeight = newValue
         }
         get {
-            return dynamicLogic.defaultSectionHeight
+            dynamicLogic.defaultSectionHeight
         }
     }
-    
+
     open var sections: BehaviorRelay<[Section<CellData>]> {
-        return dynamicLogic.sections
+        dynamicLogic.sections
     }
-    
+
     public let disposeBag = DisposeBag()
-    
+
     private var dynamicLogic = DynamicTableViewLogic()
-    
+
     open override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         if let dynamicTableView = tableView as? DynamicTableView {
             dynamicLogic = dynamicTableView.dynamicLogic
         }
-        
+
         dynamicLogic.controller = self
-        dynamicLogic.tableView = self.tableView
+        dynamicLogic.tableView = tableView
         dynamicLogic.registerNibsHandler = { [weak self] in self?.registerNibs() }
         dynamicLogic.reloadDataHandler = { [weak self] in self?.reloadData() }
-        
+
         setupViews()
         bind()
-        
+
         let sections = setupData()
         Observable.just(sections).bind(to: self.sections).disposed(by: DisposeBag())
     }
-    
+
     // MARK: - Logic
-    
-    open func setupViews() {
-        
-    }
-    
-    open func bind() {
-        
-    }
-    
-    open func registerNibs() {
-        
-    }
-    
+
+    open func setupViews() {}
+
+    open func bind() {}
+
+    open func registerNibs() {}
+
     open func reloadData() {
         tableView.reloadData()
     }
-    
+
     open func setupData() -> [Section<CellData>] {
-        return []
+        []
     }
 
     // MARK: - Table view
 
     open override func numberOfSections(in tableView: UITableView) -> Int {
-        return dynamicLogic.numberOfSections(in: tableView)
+        dynamicLogic.numberOfSections(in: tableView)
     }
-    
+
     open override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return dynamicLogic.tableView(tableView, numberOfRowsInSection: section)
+        dynamicLogic.tableView(tableView, numberOfRowsInSection: section)
     }
-    
+
     open override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        return dynamicLogic.tableView(tableView, cellForRowAt: indexPath)
+        dynamicLogic.tableView(tableView, cellForRowAt: indexPath)
     }
-    
+
     open override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return dynamicLogic.tableView(tableView, titleForHeaderInSection: section)
+        dynamicLogic.tableView(tableView, titleForHeaderInSection: section)
     }
-    
+
     open override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        return dynamicLogic.tableView(tableView, titleForFooterInSection: section)
+        dynamicLogic.tableView(tableView, titleForFooterInSection: section)
     }
-    
+
     open override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        return dynamicLogic.tableView(tableView, viewForHeaderInSection: section)
+        dynamicLogic.tableView(tableView, viewForHeaderInSection: section)
     }
-    
+
     open override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return dynamicLogic.tableView(tableView, heightForHeaderInSection: section)
+        dynamicLogic.tableView(tableView, heightForHeaderInSection: section)
     }
-    
+
     open override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        return dynamicLogic.tableView(tableView, viewForFooterInSection: section)
+        dynamicLogic.tableView(tableView, viewForFooterInSection: section)
     }
-    
+
     open override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return dynamicLogic.tableView(tableView, heightForFooterInSection: section)
+        dynamicLogic.tableView(tableView, heightForFooterInSection: section)
     }
-    
+
     open override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return dynamicLogic.tableView(tableView, heightForRowAt: indexPath)
+        dynamicLogic.tableView(tableView, heightForRowAt: indexPath)
     }
-    
+
     open override func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
-        return dynamicLogic.tableView(tableView, shouldHighlightRowAt: indexPath)
+        dynamicLogic.tableView(tableView, shouldHighlightRowAt: indexPath)
     }
-    
+
     open override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         dynamicLogic.tableView(tableView, didSelectRowAt: indexPath)
     }
-
 }

--- a/KafeityViewKit/DynamicController/Section.swift
+++ b/KafeityViewKit/DynamicController/Section.swift
@@ -8,58 +8,56 @@
 
 import UIKit
 
-
 public class Section<Element> {
-    
     public typealias HeaderFooterType = FWTwoOut<UITableView, Int, UIView?>
-    
+
     public let title: String?
     public var footerTitle: String?
-    
+
     public let header: HeaderFooterType?
     public var headerHeight: CGFloat?
-    
+
     public var footer: HeaderFooterType?
     public var footerHeight: CGFloat?
-    
+
     public var data: [Element]
-    
+
     public init(title: String?, data: [Element]) {
         self.title = title
         self.data = data
         header = nil
     }
-    
+
     public init(header: HeaderFooterType?, data: [Element]) {
-        self.title = nil
+        title = nil
         self.data = data
         self.header = header
     }
-    
+
     public init(footer: HeaderFooterType?, data: [Element]) {
-        self.title = nil
+        title = nil
         self.data = data
         self.footer = footer
         header = nil
     }
-    
+
     public init?(header: HeaderFooterType?, ifData: [Element]) {
-        if ifData.count == 0 {
+        if ifData.isEmpty {
             return nil
         }
-        
-        self.title = nil
-        self.data = ifData
+
+        title = nil
+        data = ifData
         self.header = header
     }
-    
+
     public init?(title: String?, element: Element, count: Int) {
         if count == 0 {
             return nil
         }
-        
+
         self.title = title
-        
+
         var data = [Element]()
         for _ in 0..<count {
             data.append(element)
@@ -67,14 +65,14 @@ public class Section<Element> {
         self.data = data
         header = nil
     }
-    
+
     public init?(header: HeaderFooterType?, element: Element, count: Int) {
         if count == 0 {
             return nil
         }
-        
-        self.title = nil
-        
+
+        title = nil
+
         var data = [Element]()
         for _ in 0..<count {
             data.append(element)
@@ -82,7 +80,7 @@ public class Section<Element> {
         self.data = data
         self.header = header
     }
-    
+
     public class func dataObject(sections: [Section], indexPath: IndexPath) -> Element? {
         if sections.count > indexPath.section {
             let section = sections[indexPath.section]
@@ -92,15 +90,12 @@ public class Section<Element> {
         }
         return nil
     }
-    
 }
 
 public extension Section where Element: CellData {
-    
     func setAutoHeight(autoHeight: Bool) {
         for cellData in data {
             cellData.autoHeight = autoHeight
         }
     }
-    
 }

--- a/KafeityViewKit/Extensions/NSAttributedString+Init.swift
+++ b/KafeityViewKit/Extensions/NSAttributedString+Init.swift
@@ -8,10 +8,8 @@
 
 import Foundation
 
-
 public extension NSAttributedString {
-    
-    static func text(_ text: String, hText: String, attrs: [NSAttributedString.Key : Any], hAttrs: [NSAttributedString.Key : Any]) -> NSAttributedString {
+    static func text(_ text: String, hText: String, attrs: [NSAttributedString.Key: Any], hAttrs: [NSAttributedString.Key: Any]) -> NSAttributedString {
         let attributedString = NSMutableAttributedString(string: text, attributes: attrs)
         if let range = attributedString.string.range(of: hText) {
             for attributeTuple in hAttrs {
@@ -20,18 +18,17 @@ public extension NSAttributedString {
         }
         return attributedString
     }
-    
+
     convenience init?(htmlText: String) {
         guard let htmlStringData = htmlText.data(using: String.Encoding.utf8) else {
             return nil
         }
-        
-        let options: [NSAttributedString.DocumentReadingOptionKey: AnyObject] = [.documentType : NSAttributedString.DocumentType.html as AnyObject, .characterEncoding : String.Encoding.utf8.rawValue as AnyObject]
+
+        let options: [NSAttributedString.DocumentReadingOptionKey: AnyObject] = [.documentType: NSAttributedString.DocumentType.html as AnyObject, .characterEncoding: String.Encoding.utf8.rawValue as AnyObject]
         do {
             try self.init(data: htmlStringData, options: options, documentAttributes: nil)
         } catch {
             return nil
         }
     }
-    
 }

--- a/KafeityViewKit/Extensions/UIView+Constraints.swift
+++ b/KafeityViewKit/Extensions/UIView+Constraints.swift
@@ -8,87 +8,84 @@
 
 import UIKit
 
-
 public extension UIView {
-    
     func addCenterConstraints(view: UIView, offset: CGPoint = .zero) {
         view.translatesAutoresizingMaskIntoConstraints = false
-        self.addSubview(view)
-        
-        self.addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.centerX, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.centerX, multiplier: 1.0, constant: offset.x))
-        self.addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.centerY, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.centerY, multiplier: 1.0, constant: offset.y))
+        addSubview(view)
+
+        addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.centerX, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.centerX, multiplier: 1.0, constant: offset.x))
+        addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.centerY, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.centerY, multiplier: 1.0, constant: offset.y))
     }
-    
+
     func addFullSizeConstraints(view: UIView, edgeInsets: UIEdgeInsets = .zero) {
         view.translatesAutoresizingMaskIntoConstraints = false
-        self.addSubview(view)
-        
-        //self.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-0-[view]-0-|", options: NSLayoutFormatOptions.alignAllFirstBaseline, metrics: nil, views: ["view" : view]))
-        self.addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.top, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.top, multiplier: 1.0, constant: edgeInsets.top))
-        self.addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.right, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.right, multiplier: 1.0, constant: -edgeInsets.right))
-        self.addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.bottom, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.bottom, multiplier: 1.0, constant: -edgeInsets.bottom))
-        self.addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.left, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.left, multiplier: 1.0, constant: edgeInsets.left))
+        addSubview(view)
+
+        // self.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-0-[view]-0-|", options: NSLayoutFormatOptions.alignAllFirstBaseline, metrics: nil, views: ["view" : view]))
+        addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.top, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.top, multiplier: 1.0, constant: edgeInsets.top))
+        addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.right, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.right, multiplier: 1.0, constant: -edgeInsets.right))
+        addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.bottom, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.bottom, multiplier: 1.0, constant: -edgeInsets.bottom))
+        addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.left, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.left, multiplier: 1.0, constant: edgeInsets.left))
     }
-    
+
     func addSizeConstraints(width: CGFloat? = nil, height: CGFloat? = nil) {
         translatesAutoresizingMaskIntoConstraints = false
-        
+
         if let width = width {
-            self.addConstraint(NSLayoutConstraint(item: self, attribute: NSLayoutConstraint.Attribute.width, relatedBy: NSLayoutConstraint.Relation.equal, toItem: nil, attribute: NSLayoutConstraint.Attribute.notAnAttribute, multiplier: 1.0, constant: width))
+            addConstraint(NSLayoutConstraint(item: self, attribute: NSLayoutConstraint.Attribute.width, relatedBy: NSLayoutConstraint.Relation.equal, toItem: nil, attribute: NSLayoutConstraint.Attribute.notAnAttribute, multiplier: 1.0, constant: width))
         }
         if let height = height {
-            self.addConstraint(NSLayoutConstraint(item: self, attribute: NSLayoutConstraint.Attribute.height, relatedBy: NSLayoutConstraint.Relation.equal, toItem: nil, attribute: NSLayoutConstraint.Attribute.notAnAttribute, multiplier: 1.0, constant: height))
+            addConstraint(NSLayoutConstraint(item: self, attribute: NSLayoutConstraint.Attribute.height, relatedBy: NSLayoutConstraint.Relation.equal, toItem: nil, attribute: NSLayoutConstraint.Attribute.notAnAttribute, multiplier: 1.0, constant: height))
         }
     }
-    
+
     func addConstraint(view: UIView, left: Bool = true, top: Bool = true, right: Bool = true, bottom: Bool = true) {
         view.translatesAutoresizingMaskIntoConstraints = false
         if self != view.superview {
-            self.addSubview(view)
+            addSubview(view)
         }
-        
+
         if left {
-            self.addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.left, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.left, multiplier: 1.0, constant: 0.0))
+            addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.left, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.left, multiplier: 1.0, constant: 0.0))
         }
         if top {
-            self.addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.top, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.top, multiplier: 1.0, constant: 0.0))
+            addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.top, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.top, multiplier: 1.0, constant: 0.0))
         }
         if right {
-            self.addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.right, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.right, multiplier: 1.0, constant: 0.0))
+            addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.right, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.right, multiplier: 1.0, constant: 0.0))
         }
         if bottom {
-            self.addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.bottom, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.bottom, multiplier: 1.0, constant: 0.0))
+            addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.bottom, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.bottom, multiplier: 1.0, constant: 0.0))
         }
     }
-    
+
     func addConstraint(view: UIView, left: CGFloat?, top: CGFloat?, right: CGFloat?, bottom: CGFloat?) {
         view.translatesAutoresizingMaskIntoConstraints = false
         if self != view.superview {
-            self.addSubview(view)
+            addSubview(view)
         }
 
         if left != nil {
-            self.addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.left, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.left, multiplier: 1.0, constant: left!))
+            addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.left, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.left, multiplier: 1.0, constant: left!))
         }
         if top != nil {
-            self.addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.top, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.top, multiplier: 1.0, constant: top!))
+            addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.top, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.top, multiplier: 1.0, constant: top!))
         }
         if right != nil {
-            self.addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.right, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.right, multiplier: 1.0, constant: -right!))
+            addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.right, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.right, multiplier: 1.0, constant: -right!))
         }
         if bottom != nil {
-            self.addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.bottom, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.bottom, multiplier: 1.0, constant: -bottom!))
+            addConstraint(NSLayoutConstraint(item: view, attribute: NSLayoutConstraint.Attribute.bottom, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self, attribute: NSLayoutConstraint.Attribute.bottom, multiplier: 1.0, constant: -bottom!))
         }
     }
-    
+
     func addEqualSizeConstraint(firstView: UIView, secondView: UIView, edgeInsets: UIEdgeInsets = .zero) {
-        //self.translatesAutoresizingMaskIntoConstraints = false
-        
-        //self.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-0-[view]-0-|", options: NSLayoutFormatOptions.alignAllFirstBaseline, metrics: nil, views: ["view" : view]))
-        self.addConstraint(NSLayoutConstraint(item: firstView, attribute: NSLayoutConstraint.Attribute.top, relatedBy: NSLayoutConstraint.Relation.equal, toItem: secondView, attribute: NSLayoutConstraint.Attribute.top, multiplier: 1.0, constant: edgeInsets.top))
-        self.addConstraint(NSLayoutConstraint(item: firstView, attribute: NSLayoutConstraint.Attribute.right, relatedBy: NSLayoutConstraint.Relation.equal, toItem: secondView, attribute: NSLayoutConstraint.Attribute.right, multiplier: 1.0, constant: edgeInsets.right))
-        self.addConstraint(NSLayoutConstraint(item: firstView, attribute: NSLayoutConstraint.Attribute.bottom, relatedBy: NSLayoutConstraint.Relation.equal, toItem: secondView, attribute: NSLayoutConstraint.Attribute.bottom, multiplier: 1.0, constant: edgeInsets.bottom))
-        self.addConstraint(NSLayoutConstraint(item: firstView, attribute: NSLayoutConstraint.Attribute.left, relatedBy: NSLayoutConstraint.Relation.equal, toItem: secondView, attribute: NSLayoutConstraint.Attribute.left, multiplier: 1.0, constant: edgeInsets.left))
+        // self.translatesAutoresizingMaskIntoConstraints = false
+
+        // self.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-0-[view]-0-|", options: NSLayoutFormatOptions.alignAllFirstBaseline, metrics: nil, views: ["view" : view]))
+        addConstraint(NSLayoutConstraint(item: firstView, attribute: NSLayoutConstraint.Attribute.top, relatedBy: NSLayoutConstraint.Relation.equal, toItem: secondView, attribute: NSLayoutConstraint.Attribute.top, multiplier: 1.0, constant: edgeInsets.top))
+        addConstraint(NSLayoutConstraint(item: firstView, attribute: NSLayoutConstraint.Attribute.right, relatedBy: NSLayoutConstraint.Relation.equal, toItem: secondView, attribute: NSLayoutConstraint.Attribute.right, multiplier: 1.0, constant: edgeInsets.right))
+        addConstraint(NSLayoutConstraint(item: firstView, attribute: NSLayoutConstraint.Attribute.bottom, relatedBy: NSLayoutConstraint.Relation.equal, toItem: secondView, attribute: NSLayoutConstraint.Attribute.bottom, multiplier: 1.0, constant: edgeInsets.bottom))
+        addConstraint(NSLayoutConstraint(item: firstView, attribute: NSLayoutConstraint.Attribute.left, relatedBy: NSLayoutConstraint.Relation.equal, toItem: secondView, attribute: NSLayoutConstraint.Attribute.left, multiplier: 1.0, constant: edgeInsets.left))
     }
-    
 }

--- a/KafeityViewKit/FW/FWBase.swift
+++ b/KafeityViewKit/FW/FWBase.swift
@@ -8,11 +8,6 @@
 
 import Foundation
 
-
 public class FWBase {
-    
-    public init() {
-        
-    }
-    
+    public init() {}
 }

--- a/KafeityViewKit/FW/FWFour.swift
+++ b/KafeityViewKit/FW/FWFour.swift
@@ -8,11 +8,9 @@
 
 import Foundation
 
-
 public class FWFour<FirstInput: Any, SecondInput: Any, ThirdInput: Any, FourthInput: Any>: FWBase {
-    
     private var function: (FirstInput, SecondInput, ThirdInput, FourthInput) -> Void
-    
+
     public init<Owner: AnyObject>(_ owner: Owner, _ closure: @escaping (Owner) -> ((FirstInput, SecondInput, ThirdInput, FourthInput) -> Void)) {
         function = { [weak owner] firstInput, secondInput, thirdInput, fourthInput in
             if let owner = owner {
@@ -20,9 +18,8 @@ public class FWFour<FirstInput: Any, SecondInput: Any, ThirdInput: Any, FourthIn
             }
         }
     }
-    
+
     public func perform(_ firstInput: FirstInput, _ secondInput: SecondInput, _ thirdInput: ThirdInput, _ fourthInput: FourthInput) {
         function(firstInput, secondInput, thirdInput, fourthInput)
     }
-    
 }

--- a/KafeityViewKit/FW/FWFourOut.swift
+++ b/KafeityViewKit/FW/FWFourOut.swift
@@ -8,25 +8,21 @@
 
 import Foundation
 
-
 public class FWFourOut<FirstInput: Any, SecondInput: Any, ThirdInput: Any, FourthInput: Any, Output: Any>: FWBase {
-    
     private var function: (FirstInput, SecondInput, ThirdInput, FourthInput) -> Output
-    
+
     public init<Owner: AnyObject>(_ owner: Owner, _ closure: @escaping (Owner) -> ((FirstInput, SecondInput, ThirdInput, FourthInput) -> Output), defaultValue: Output? = nil) {
         function = { [weak owner] firstInput, secondInput, thirdInput, fourthInput in
             if let owner = owner {
                 return closure(owner)(firstInput, secondInput, thirdInput, fourthInput)
-            }
-            else if let defaultValue = defaultValue {
+            } else if let defaultValue = defaultValue {
                 return defaultValue
             }
             return closure(owner!)(firstInput, secondInput, thirdInput, fourthInput)
         }
     }
-    
+
     public func perform(_ firstInput: FirstInput, _ secondInput: SecondInput, _ thirdInput: ThirdInput, _ fourthInput: FourthInput) -> Output {
-        return function(firstInput, secondInput, thirdInput, fourthInput)
+        function(firstInput, secondInput, thirdInput, fourthInput)
     }
-    
 }

--- a/KafeityViewKit/FW/FWOne.swift
+++ b/KafeityViewKit/FW/FWOne.swift
@@ -8,11 +8,9 @@
 
 import Foundation
 
-
 public class FWOne<Input: Any>: FWBase {
-    
     private var function: (Input) -> Void
-    
+
     public init<Owner: AnyObject>(_ owner: Owner, _ closure: @escaping (Owner) -> ((Input) -> Void)) {
         function = { [weak owner] input in
             if let owner = owner {
@@ -20,9 +18,8 @@ public class FWOne<Input: Any>: FWBase {
             }
         }
     }
-    
+
     public func perform(_ input: Input) {
         function(input)
     }
-    
 }

--- a/KafeityViewKit/FW/FWOneOut.swift
+++ b/KafeityViewKit/FW/FWOneOut.swift
@@ -8,25 +8,21 @@
 
 import Foundation
 
-
 public class FWOneOut<Input: Any, Output: Any>: FWBase {
-    
     private var function: (Input) -> Output
-    
+
     public init<Owner: AnyObject>(_ owner: Owner, _ closure: @escaping (Owner) -> ((Input) -> Output), defaultValue: Output? = nil) {
         function = { [weak owner] input in
             if let owner = owner {
                 return closure(owner)(input)
-            }
-            else if let defaultValue = defaultValue {
+            } else if let defaultValue = defaultValue {
                 return defaultValue
             }
             return closure(owner!)(input)
         }
     }
-    
+
     public func perform(_ input: Input) -> Output {
-        return function(input)
+        function(input)
     }
-    
 }

--- a/KafeityViewKit/FW/FWThree.swift
+++ b/KafeityViewKit/FW/FWThree.swift
@@ -8,11 +8,9 @@
 
 import Foundation
 
-
 public class FWThree<FirstInput: Any, SecondInput: Any, ThirdInput: Any>: FWBase {
-    
     private var function: (FirstInput, SecondInput, ThirdInput) -> Void
-    
+
     public init<Owner: AnyObject>(_ owner: Owner, _ closure: @escaping (Owner) -> ((FirstInput, SecondInput, ThirdInput) -> Void)) {
         function = { [weak owner] firstInput, secondInput, thirdInput in
             if let owner = owner {
@@ -20,9 +18,8 @@ public class FWThree<FirstInput: Any, SecondInput: Any, ThirdInput: Any>: FWBase
             }
         }
     }
-    
+
     public func perform(_ firstInput: FirstInput, _ secondInput: SecondInput, _ thirdInput: ThirdInput) {
         function(firstInput, secondInput, thirdInput)
     }
-    
 }

--- a/KafeityViewKit/FW/FWThreeOut.swift
+++ b/KafeityViewKit/FW/FWThreeOut.swift
@@ -8,25 +8,21 @@
 
 import Foundation
 
-
 public class FWThreeOut<FirstInput: Any, SecondInput: Any, ThirdInput: Any, Output: Any>: FWBase {
-    
     private var function: (FirstInput, SecondInput, ThirdInput) -> Output
-    
+
     public init<Owner: AnyObject>(_ owner: Owner, _ closure: @escaping (Owner) -> ((FirstInput, SecondInput, ThirdInput) -> Output), defaultValue: Output? = nil) {
         function = { [weak owner] firstInput, secondInput, thirdInput in
             if let owner = owner {
                 return closure(owner)(firstInput, secondInput, thirdInput)
-            }
-            else if let defaultValue = defaultValue {
+            } else if let defaultValue = defaultValue {
                 return defaultValue
             }
             return closure(owner!)(firstInput, secondInput, thirdInput)
         }
     }
-    
+
     public func perform(_ firstInput: FirstInput, _ secondInput: SecondInput, _ thirdInput: ThirdInput) -> Output {
-        return function(firstInput, secondInput, thirdInput)
+        function(firstInput, secondInput, thirdInput)
     }
-    
 }

--- a/KafeityViewKit/FW/FWTwo.swift
+++ b/KafeityViewKit/FW/FWTwo.swift
@@ -8,11 +8,9 @@
 
 import Foundation
 
-
 public class FWTwo<FirstInput: Any, SecondInput: Any>: FWBase {
-    
     private var function: (FirstInput, SecondInput) -> Void
-    
+
     public init<Owner: AnyObject>(_ owner: Owner, _ closure: @escaping (Owner) -> ((FirstInput, SecondInput) -> Void)) {
         function = { [weak owner] firstInput, secondInput in
             if let owner = owner {
@@ -20,9 +18,8 @@ public class FWTwo<FirstInput: Any, SecondInput: Any>: FWBase {
             }
         }
     }
-    
+
     public func perform(_ firstInput: FirstInput, _ secondInput: SecondInput) {
         function(firstInput, secondInput)
     }
-    
 }

--- a/KafeityViewKit/FW/FWTwoOut.swift
+++ b/KafeityViewKit/FW/FWTwoOut.swift
@@ -8,25 +8,21 @@
 
 import Foundation
 
-
 public class FWTwoOut<FirstInput: Any, SecondInput: Any, Output: Any>: FWBase {
-    
     private var function: (FirstInput, SecondInput) -> Output
-    
+
     public init<Owner: AnyObject>(_ owner: Owner, _ closure: @escaping (Owner) -> ((FirstInput, SecondInput) -> Output), defaultValue: Output? = nil) {
         function = { [weak owner] firstInput, secondInput in
             if let owner = owner {
                 return closure(owner)(firstInput, secondInput)
-            }
-            else if let defaultValue = defaultValue {
+            } else if let defaultValue = defaultValue {
                 return defaultValue
             }
             return closure(owner!)(firstInput, secondInput)
         }
     }
-    
+
     public func perform(_ firstInput: FirstInput, _ secondInput: SecondInput) -> Output {
-        return function(firstInput, secondInput)
+        function(firstInput, secondInput)
     }
-    
 }

--- a/KafeityViewKit/FW/FWVoid.swift
+++ b/KafeityViewKit/FW/FWVoid.swift
@@ -8,11 +8,9 @@
 
 import Foundation
 
-
 public class FWVoid: FWBase {
-    
     private let function: () -> Void
-    
+
     public init<Owner: AnyObject>(_ owner: Owner, _ closure: @escaping (Owner) -> (() -> Void)) {
         function = { [weak owner] in
             if let owner = owner {
@@ -20,9 +18,8 @@ public class FWVoid: FWBase {
             }
         }
     }
-    
+
     public func perform() {
         function()
     }
-    
 }

--- a/KafeityViewKit/FW/FWVoidOut.swift
+++ b/KafeityViewKit/FW/FWVoidOut.swift
@@ -8,25 +8,21 @@
 
 import Foundation
 
-
 public class FWVoidOut<Output: Any>: FWBase {
-    
     private let function: () -> Output
-    
+
     public init<Owner: AnyObject>(_ owner: Owner, _ closure: @escaping (Owner) -> (() -> Output), defaultValue: Output? = nil) {
         function = { [weak owner] in
             if let owner = owner {
-               return closure(owner)()
-            }
-            else if let defaultValue = defaultValue {
+                return closure(owner)()
+            } else if let defaultValue = defaultValue {
                 return defaultValue
             }
             return closure(owner!)()
         }
     }
-    
+
     public func perform() -> Output {
-        return function()
+        function()
     }
-    
 }

--- a/KafeityViewKit/Layers/FadeGradientLayer.swift
+++ b/KafeityViewKit/Layers/FadeGradientLayer.swift
@@ -8,22 +8,17 @@
 
 import UIKit
 
-
 public enum FadeGradientType {
-    
     case leftToRight
     case bottomToTop
     case rightToLeft
     case topToBottom
-    
 }
 
-
 open class FadeGradientLayer: CAGradientLayer {
-    
     public init(type: FadeGradientType, startColor: UIColor = .white, endColor: UIColor = .black) {
         super.init()
-        
+
         switch type {
         case .leftToRight:
             colors = [startColor.cgColor, endColor.withAlphaComponent(0.0).cgColor]
@@ -39,13 +34,12 @@ open class FadeGradientLayer: CAGradientLayer {
             colors = [startColor.cgColor, endColor.withAlphaComponent(0.0).cgColor]
         }
     }
-    
+
     public override init(layer: Any) {
         super.init(layer: layer)
     }
-    
+
     public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
 }

--- a/KafeityViewKit/NavigationControllers/NavigationBarHelper.swift
+++ b/KafeityViewKit/NavigationControllers/NavigationBarHelper.swift
@@ -8,23 +8,20 @@
 
 import UIKit
 
-
 public enum NavigationBarHelper {
-    
     public static func solid(_ viewController: UIViewController, color: UIColor, titleColor: UIColor? = nil, tintColor: UIColor? = nil, largeTitles: Bool = true) {
-        
-        let titleAttributes = titleColor == nil ? [:] : [NSAttributedString.Key.foregroundColor : titleColor!] as [NSAttributedString.Key : Any]
+        let titleAttributes = titleColor == nil ? [:] : [NSAttributedString.Key.foregroundColor: titleColor!] as [NSAttributedString.Key: Any]
         let navigationBar = viewController.navigationController?.navigationBar
-        
+
         if #available(iOS 13.0, *) {
             let navigationBarAppearance = UINavigationBarAppearance()
             navigationBarAppearance.backgroundColor = color
-            
+
             if titleColor != nil {
                 navigationBarAppearance.titleTextAttributes = titleAttributes
                 navigationBarAppearance.largeTitleTextAttributes = titleAttributes
             }
-            
+
             navigationBar?.standardAppearance = navigationBarAppearance
             navigationBar?.compactAppearance = navigationBarAppearance
             navigationBar?.scrollEdgeAppearance = navigationBarAppearance
@@ -39,15 +36,14 @@ public enum NavigationBarHelper {
             navigationBar?.backgroundColor = color
             navigationBar?.isTranslucent = true
         }
-        
+
         if #available(iOS 11.0, *) {
             navigationBar?.prefersLargeTitles = true
             viewController.navigationItem.largeTitleDisplayMode = largeTitles ? .always : .never
         }
-        
+
         if let tintColor = tintColor {
             navigationBar?.tintColor = tintColor
         }
     }
-    
 }

--- a/KafeityViewKit/Routers/Router.swift
+++ b/KafeityViewKit/Routers/Router.swift
@@ -8,12 +8,8 @@
 
 import UIKit
 
-
 open class Router {
-
-    public init() {
-        
-    }
+    public init() {}
 
     public func show(_ vc: UIViewController, from: UIViewController, withTransition transition: Transition = .push) {
         transition.perform(from: from, to: vc)
@@ -26,7 +22,7 @@ open class Router {
     public func pop(from nvc: UINavigationController, animated: Bool = true) {
         nvc.popViewController(animated: animated)
     }
-    
+
     public func dismissToRoot(_ controller: UIViewController, animated: Bool = true) {
         if let nvc = controller as? UINavigationController {
             nvc.popToRootViewController(animated: animated)
@@ -34,12 +30,11 @@ open class Router {
             controller.navigationController?.popToRootViewController(animated: animated)
         }
     }
-    
+
     public func showError(_ vc: UIViewController, errorMessage: String) {
         let title = "Oops"
         let alert = UIAlertController(title: title, message: errorMessage, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "OK", style: UIAlertAction.Style.default, handler: nil))
-        vc.present(alert, animated: true, completion:  nil)
+        vc.present(alert, animated: true, completion: nil)
     }
-    
 }

--- a/KafeityViewKit/Routers/Transition.swift
+++ b/KafeityViewKit/Routers/Transition.swift
@@ -8,20 +8,18 @@
 
 import UIKit
 
-
 public enum Transition {
-    
     case push
     case modal(animated: Bool)
     case replace(animated: Bool)
-    
+
     public func perform(from: UIViewController, to: UIViewController) {
         switch self {
         case .push:
             from.show(to, sender: nil)
-        case .modal(let animated):
+        case let .modal(animated):
             from.present(to, animated: animated, completion: nil)
-        case .replace(let animated):
+        case let .replace(animated):
             from.navigationController?.setViewControllers([to], animated: animated)
         }
     }

--- a/KafeityViewKit/Utilities/KeyboardManager.swift
+++ b/KafeityViewKit/Utilities/KeyboardManager.swift
@@ -8,41 +8,39 @@
 
 import UIKit
 
-
 public class KeyboardManager {
-    
     public var heightChanged: ((CGFloat) -> Void)?
-    
+
     public private(set) var height: CGFloat = 0.0 {
         didSet {
             heightChanged?(height)
         }
     }
-    
-    private var userInfo: [AnyHashable : Any]?
-    
+
+    private var userInfo: [AnyHashable: Any]?
+
     public init() {
         addObservers()
     }
-    
+
     deinit {
         NotificationCenter.default.removeObserver(self)
     }
-    
+
     public func animate(view: UIView) {
         let duration = userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double ?? 0.3
         let curve = UIView.KeyframeAnimationOptions(rawValue: userInfo?[UIResponder.keyboardAnimationCurveUserInfoKey] as? UInt ?? 0)
-        
+
         UIView.animateKeyframes(withDuration: duration, delay: 0.0, options: curve, animations: {
             view.layoutIfNeeded()
         }, completion: nil)
     }
-    
+
     private func addObservers() {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(notification:)), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(notification:)), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
-    
+
     @objc
     private func keyboardWillShow(notification: Notification) {
         guard let frame = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as AnyObject).cgRectValue else {
@@ -51,7 +49,7 @@ public class KeyboardManager {
         userInfo = notification.userInfo
         height = frame.height
     }
-    
+
     @objc
     private func keyboardWillHide(notification: Notification) {
         guard let _ = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as AnyObject).cgRectValue else {

--- a/KafeityViewKit/ViewControllers/BaseNC.swift
+++ b/KafeityViewKit/ViewControllers/BaseNC.swift
@@ -6,13 +6,9 @@
 //  Copyright © 2020 SKOUMAL, s.r.o. All rights reserved.
 //
 
-import UIKit
 import RxSwift
-
+import UIKit
 
 open class BaseNC: UINavigationController {
-
     public let disposeBag = DisposeBag()
-    
 }
-

--- a/KafeityViewKit/ViewControllers/BaseTableVC.swift
+++ b/KafeityViewKit/ViewControllers/BaseTableVC.swift
@@ -6,16 +6,14 @@
 //  Copyright © 2020 SKOUMAL, s.r.o. All rights reserved.
 //
 
-import UIKit
 import RxSwift
-
+import UIKit
 
 open class BaseTableVC: UITableViewController {
-
     public let disposeBag = DisposeBag()
-    
+
     open override var preferredStatusBarStyle: UIStatusBarStyle {
-        return .lightContent
+        .lightContent
     }
 
     open override func viewDidLoad() {
@@ -23,19 +21,15 @@ open class BaseTableVC: UITableViewController {
         setupViews()
         bind()
     }
-    
+
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         reload()
     }
 
-    open func setupViews() {
-    }
+    open func setupViews() {}
 
-    open func bind() {
-    }
-    
-    open func reload() {
-    }
-    
+    open func bind() {}
+
+    open func reload() {}
 }

--- a/KafeityViewKit/ViewControllers/BaseVC.swift
+++ b/KafeityViewKit/ViewControllers/BaseVC.swift
@@ -6,17 +6,15 @@
 //  Copyright © 2020 SKOUMAL, s.r.o. All rights reserved.
 //
 
-import UIKit
 import RxSwift
-
+import UIKit
 
 open class BaseVC<ContentView: UIView, ViewModel, RouterType: Router>: UIViewController {
-    
     public var router: RouterType!
     public var viewModel: ViewModel!
-    
+
     public var contentView: ContentView {
-        return view as! ContentView
+        view as! ContentView
     }
 
     public let disposeBag = DisposeBag()
@@ -28,10 +26,7 @@ open class BaseVC<ContentView: UIView, ViewModel, RouterType: Router>: UIViewCon
         bind()
     }
 
-    open func setupViews() {
-    }
+    open func setupViews() {}
 
-    open func bind() {
-    }
-    
+    open func bind() {}
 }

--- a/KafeityViewKit/Views/BaseCollectionView.swift
+++ b/KafeityViewKit/Views/BaseCollectionView.swift
@@ -6,33 +6,30 @@
 //  Copyright © 2020 SKOUMAL, s.r.o. All rights reserved.
 //
 
-import UIKit
 import RxSwift
-
+import UIKit
 
 open class BaseCollectionCell: UICollectionViewCell, ReusableCell {
-    
     public private(set) var disposeBag = DisposeBag()
-    
+
     open override func awakeFromNib() {
         super.awakeFromNib()
         setup()
     }
-    
+
     public override init(frame: CGRect) {
         super.init(frame: frame)
         setup()
     }
-    
+
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
-    
+
     open override func prepareForReuse() {
         super.prepareForReuse()
         disposeBag = DisposeBag()
     }
-    
-    open func setup() {
-    }
+
+    open func setup() {}
 }

--- a/KafeityViewKit/Views/BaseTableCell.swift
+++ b/KafeityViewKit/Views/BaseTableCell.swift
@@ -6,34 +6,30 @@
 //  Copyright © 2020 SKOUMAL, s.r.o. All rights reserved.
 //
 
-import UIKit
 import RxSwift
-
+import UIKit
 
 open class BaseTableCell: UITableViewCell, ReusableCell {
-    
     public private(set) var disposeBag = DisposeBag()
-    
+
     open override func awakeFromNib() {
         super.awakeFromNib()
         setup()
     }
-    
+
     open override func prepareForReuse() {
         super.prepareForReuse()
         disposeBag = DisposeBag()
     }
-    
+
     public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setup()
     }
-    
+
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
-    
-    open func setup() {
-    }
-    
+
+    open func setup() {}
 }

--- a/KafeityViewKit/Views/BaseView.swift
+++ b/KafeityViewKit/Views/BaseView.swift
@@ -6,64 +6,56 @@
 //  Copyright © 2020 SKOUMAL, s.r.o. All rights reserved.
 //
 
-import UIKit
 import RxSwift
-
+import UIKit
 
 open class BaseView: UIView {
-    
     public let disposeBag = DisposeBag()
-    
+
     deinit {
         debugPrint("DEINIT \(String(describing: self))")
     }
-    
+
     public convenience init() {
         self.init(frame: .zero)
     }
-    
+
     public override init(frame: CGRect) {
         super.init(frame: frame)
         setup()
         bind()
     }
-    
+
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-
     }
-    
+
     open override func awakeFromNib() {
         super.awakeFromNib()
         setup()
         bind()
     }
-    
+
     open func xibSetup() -> UIView {
         let contentView = loadFromNib()
         contentView.backgroundColor = UIColor.clear
         addFullSizeConstraints(view: contentView)
         return contentView
     }
-    
-    open func setup() {
-        
-    }
-    
-    open func bind() {
-        
-    }
-    
+
+    open func setup() {}
+
+    open func bind() {}
+
     private func loadFromNib<T: UIView>() -> T {
         let selfType = type(of: self)
         let bundle = Bundle(for: selfType)
         let nibName = String(describing: selfType)
         let nib = UINib(nibName: nibName, bundle: bundle)
-        
+
         guard let view = nib.instantiate(withOwner: self, options: nil).first as? T else {
             fatalError("Error loading nib with name \(nibName)")
         }
         return view
     }
-    
 }

--- a/KafeityViewKit/Views/Cells/ReusableCell.swift
+++ b/KafeityViewKit/Views/Cells/ReusableCell.swift
@@ -8,22 +8,17 @@
 
 import UIKit
 
-
-public protocol ReusableCell: class {
-
+public protocol ReusableCell: AnyObject {
     static var defaultReuseId: String { get }
     static var defaultNibName: String { get }
-
 }
 
 public extension ReusableCell where Self: UIView {
-
     static var defaultReuseId: String {
-        return String(describing: self)
+        String(describing: self)
     }
 
     static var defaultNibName: String {
-        return defaultReuseId
+        defaultReuseId
     }
-
 }

--- a/KafeityViewKit/Views/Cells/ReusableHeaderFooter.swift
+++ b/KafeityViewKit/Views/Cells/ReusableHeaderFooter.swift
@@ -8,21 +8,17 @@
 
 import UIKit
 
-
-public protocol ReusableHeaderFooter: class {
-
+public protocol ReusableHeaderFooter: AnyObject {
     static var defaultReuseId: String { get }
     static var defaultNibName: String { get }
-    
 }
 
 public extension ReusableHeaderFooter where Self: UIView {
-
     static var defaultReuseId: String {
-        return String(describing: self)
+        String(describing: self)
     }
 
     static var defaultNibName: String {
-        return defaultReuseId
+        defaultReuseId
     }
 }

--- a/KafeityViewKit/Views/Cells/UICollectionView+Reuse.swift
+++ b/KafeityViewKit/Views/Cells/UICollectionView+Reuse.swift
@@ -8,17 +8,14 @@
 
 import UIKit
 
-
 public extension UICollectionView {
-    
     func dequeueReusableCell<T: UICollectionViewCell>(for indexPath: IndexPath) -> T where T: ReusableCell {
         let identifier = T.defaultReuseId
         return dequeueReusableCell(withReuseIdentifier: identifier, for: indexPath) as! T
     }
-    
+
     func register<T: ReusableCell>(cell: T.Type) {
         let nib = UINib(nibName: cell.defaultNibName, bundle: nil)
         register(nib, forCellWithReuseIdentifier: cell.defaultReuseId)
     }
-    
 }

--- a/KafeityViewKit/Views/Cells/UITableView+Reuse.swift
+++ b/KafeityViewKit/Views/Cells/UITableView+Reuse.swift
@@ -8,9 +8,7 @@
 
 import UIKit
 
-
 public extension UITableView {
-
     func register<T: ReusableCell>(cell: T.Type) {
         let bundle = Bundle(for: T.self)
         let nib = UINib(nibName: cell.defaultNibName, bundle: bundle)

--- a/KafeityViewKitTests/KafeityViewKitTests.swift
+++ b/KafeityViewKitTests/KafeityViewKitTests.swift
@@ -6,11 +6,10 @@
 //  Copyright © 2020 SKOUMAL, s.r.o. All rights reserved.
 //
 
-import XCTest
 @testable import KafeityViewKit
+import XCTest
 
 class KafeityViewKitTests: XCTestCase {
-
     override func setUp() {
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
@@ -26,9 +25,8 @@ class KafeityViewKitTests: XCTestCase {
 
     func testPerformanceExample() {
         // This is an example of a performance test case.
-        self.measure {
+        measure {
             // Put the code you want to measure the time of here.
         }
     }
-
 }


### PR DESCRIPTION
- Added `.swiftformat` with a set of rules to be enforced
- Formatted code

The tool can be found [here](https://github.com/nicklockwood/SwiftFormat), list of all available rules [here](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md).

To format code, one simply calls `swiftformat .` from the project's directory. This can be set-up to be run on a CI server in the future.